### PR TITLE
chore: Build all images with `goreleaser`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore goreleaser built artifacts
+dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,25 +1,55 @@
+---
 before:
   hooks:
     - go mod download
+
 builds:
-  - env:
-      - CGO_ENABLED=0
+  - env: [CGO_ENABLED=0]
     goos:
       - darwin
       - linux
     goarch:
       - amd64
       - arm64
+
 checksum:
   name_template: 'checksums.txt'
+
 snapshot:
   name_template: "{{ .ShortCommit }}"
+
 changelog:
   skip: true
+
 release:
   draft: true
+
 dockers:
-  - dockerfile: Dockerfile.goreleaser
+  - dockerfile: Dockerfile
     image_templates:
-      - "shoekstra/repo-settings:latest"
-      - "shoekstra/repo-settings:{{ .Tag }}"
+      - "shoekstra/{{ .ProjectName }}:latest"
+      - "shoekstra/{{ .ProjectName }}:{{ .Tag }}"
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.url=https://github.com/shoekstra/{{ .ProjectName }}
+      - --label=org.opencontainers.image.source=https://github.com/shoekstra/{{ .ProjectName }}
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.licenses=Apache-2.0
+  - dockerfile: Dockerfile.alpine
+    image_templates:
+      - "shoekstra/{{ .ProjectName }}:latest-alpine"
+      - "shoekstra/{{ .ProjectName }}:{{ .Tag }}-alpine"
+    build_flag_templates:
+      - --platform=linux/amd64
+      - --label=org.opencontainers.image.title={{ .ProjectName }}
+      - --label=org.opencontainers.image.description={{ .ProjectName }}
+      - --label=org.opencontainers.image.url=https://github.com/shoekstra/{{ .ProjectName }}
+      - --label=org.opencontainers.image.source=https://github.com/shoekstra/{{ .ProjectName }}
+      - --label=org.opencontainers.image.version={{ .Version }}
+      - --label=org.opencontainers.image.created={{ time "2006-01-02T15:04:05Z07:00" }}
+      - --label=org.opencontainers.image.revision={{ .FullCommit }}
+      - --label=org.opencontainers.image.licenses=Apache-2.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,35 +1,3 @@
-### Step 1 - build app
-
-FROM golang:1.12-alpine AS builder
-
-# Install deps
-#   - git required for fetching dependencies
-#   - ca-certificates required to call HTTPS endpoints
-RUN apk update && \
-    apk add --no-cache git ca-certificates && \
-    update-ca-certificates
-
-# Create app user
-RUN adduser -D -g '' repo-settings
-
-WORKDIR /app
-COPY . .
-
-RUN go mod download
-RUN go mod verify
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /bin/repo-settings
-
-### Step 2 - build app image
-
 FROM scratch
-
-# Import from builder
-COPY --from=builder /bin/repo-settings /bin/repo-settings
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-
-# Use an unprivileged user
-USER repo-settings
-
-# Run our app
-ENTRYPOINT ["/bin/repo-settings"]
+ENTRYPOINT ["/repo-settings"]
+COPY repo-settings /

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,35 +1,3 @@
-### Step 1 - build app
-
-FROM golang:1.12-alpine AS builder
-
-# Install deps
-#   - git required for fetching dependencies
-#   - ca-certificates required to call HTTPS endpoints
-RUN apk update && \
-    apk add --no-cache git ca-certificates && \
-    update-ca-certificates
-
-# Create app user
-RUN adduser -D -g '' repo-settings
-
-WORKDIR /app
-COPY . .
-
-RUN go mod download
-RUN go mod verify
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /bin/repo-settings
-
-### Step 2 - build app image
-
 FROM alpine
-
-# Import from builder
-COPY --from=builder /bin/repo-settings /bin/repo-settings
-COPY --from=builder /etc/passwd /etc/passwd
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-
-# Use an unprivileged user
-USER repo-settings
-
-# Run our app
-ENTRYPOINT ["/bin/repo-settings"]
+ENTRYPOINT ["/repo-settings"]
+COPY repo-settings /

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,3 +1,0 @@
-FROM scratch
-ENTRYPOINT ["/repo-settings"]
-COPY repo-settings /


### PR DESCRIPTION
- Build both images (alpine- and scratch-based) with `goreleaser`
- Ignore goreleaser built artifacts
