### PR TITLE
misc: Add dependabot config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,10 @@
+---
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: fix


### PR DESCRIPTION
Need to add `.github/dependabot.yaml` to specify a commit msg prefix so
our PR validator works as expected.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
